### PR TITLE
Replace miq-uuid with uuidtools

### DIFF
--- a/lib/virtfs/ntfs/attrib_object_id.rb
+++ b/lib/virtfs/ntfs/attrib_object_id.rb
@@ -22,10 +22,10 @@ module NTFS
       raise "MIQ(NTFS::ObjectId.initialize) Nil buffer" if buf.nil?
       buf = buf.read(buf.length) if buf.kind_of?(DataRun)
       len = 16
-      @objectId       = MiqUUID.parse_raw(buf[len * 0, len])
-      @birthVolumeId  = MiqUUID.parse_raw(buf[len * 1, len]) if buf.length > 16
-      @birthObjectId  = MiqUUID.parse_raw(buf[len * 2, len]) if buf.length > 16
-      @domainId       = MiqUUID.parse_raw(buf[len * 3, len]) if buf.length > 16
+      @objectId       = UUIDTools::UUID.parse_raw(buf[len * 0, len])
+      @birthVolumeId  = UUIDTools::UUID.parse_raw(buf[len * 1, len]) if buf.length > 16
+      @birthObjectId  = UUIDTools::UUID.parse_raw(buf[len * 2, len]) if buf.length > 16
+      @domainId       = UUIDTools::UUID.parse_raw(buf[len * 3, len]) if buf.length > 16
     end
 
     def dump

--- a/lib/virtfs/ntfs/attrib_object_id.rb
+++ b/lib/virtfs/ntfs/attrib_object_id.rb
@@ -1,4 +1,4 @@
-require 'util/miq-uuid'
+require 'uuidtools'
 
 module NTFS
   # There is no real data definition for this class - it consists entirely of GUIDs.

--- a/virtfs-ntfs.gemspec
+++ b/virtfs-ntfs.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency "uuidtools", "~> 2.2"
+
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This updates the code to use uuidtools instead of miq-uuid, which is being removed from gems-pending. As it stands the MiqUUID.parse_raw call would not work anyway.

I also updated the gemspec to add the uuidtools dependency, and loosen the version requirements for bundler and rake (we should not care).