### PR TITLE
drop sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 cache: bundler
 language: ruby
 rvm:


### PR DESCRIPTION
we can get rid of `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration