### PR TITLE
Remove miq-unicode dependency, encode manually

### DIFF
--- a/lib/virtfs/ntfs/attrib_attribute_list.rb
+++ b/lib/virtfs/ntfs/attrib_attribute_list.rb
@@ -1,6 +1,5 @@
 require 'fs/ntfs/utils'
 require 'binary_struct'
-require 'util/miq-unicode'
 
 module NTFS
   #
@@ -76,7 +75,7 @@ module NTFS
 
         # If there's a name get it.
         len = aal['name_length'] * 2
-        aal['name'] = buf[pos + aal['name_offset'], len].UnicodeToUtf8 if len > 0
+        aal['name'] = NTFS::Utils.UnicodeToUtf8(buf[pos + aal['name_offset'], len]) if len > 0
 
         # Log instances of funky references.
         aal['mft'] = NTFS::Utils.MkRef(aal['mft_reference'])[1]

--- a/lib/virtfs/ntfs/attrib_file_name.rb
+++ b/lib/virtfs/ntfs/attrib_file_name.rb
@@ -1,7 +1,6 @@
 require 'fs/ntfs/utils'
 require 'util/win32/nt_util'
 require 'binary_struct'
-require 'util/miq-unicode'
 require 'fs/ntfs/attrib_standard_information'
 
 module NTFS
@@ -47,7 +46,7 @@ module NTFS
     NS_DOS    = 2
     NS_DOSWIN = 3
 
-    UNNAMED = '[unnamed]'.AsciiToUtf8.freeze
+    UNNAMED = '[unnamed]'.freeze
 
     def initialize(buf)
       raise "MIQ(NTFS::FileName.initialize) Nil buffer" if buf.nil?
@@ -62,8 +61,8 @@ module NTFS
       @refParent   = NTFS::Utils.MkRef(@afn['ref_to_parent_dir'])
 
       # If there's a name get it.
-      len          = @afn['name_length'] * 2
-      @name        = buf[0, len].UnicodeToUtf8 if len > 0
+      len = @afn['name_length'] * 2
+      @name = NTFS::Utils.UnicodeToUtf8(buf[0, len]) if len > 0
 
       # If name is nil use NT standard unnamed.
       @name ||= UNNAMED.dup

--- a/lib/virtfs/ntfs/attrib_header.rb
+++ b/lib/virtfs/ntfs/attrib_header.rb
@@ -1,5 +1,4 @@
 require 'binary_struct'
-require 'util/miq-unicode'
 require 'fs/ntfs/utils'
 require 'fs/ntfs/attrib_type'
 
@@ -102,7 +101,7 @@ module NTFS
       offset += len
 
       # If there's a name get it.
-      @name = buf[offset, (@namelen * 2)].UnicodeToUtf8  if @namelen != 0
+      @name = NTFS::Utils.UnicodeToUtf8(buf[offset, (@namelen * 2)]) if @namelen != 0
     end
 
     def get_value(buf, boot_sector)

--- a/lib/virtfs/ntfs/attrib_index_root.rb
+++ b/lib/virtfs/ntfs/attrib_index_root.rb
@@ -1,5 +1,4 @@
 require 'binary_struct'
-require 'util/miq-unicode'
 require 'fs/ntfs/index_node_header'
 require 'fs/ntfs/directory_index_node'
 require 'fs/ntfs/index_record_header'

--- a/lib/virtfs/ntfs/attrib_volume_name.rb
+++ b/lib/virtfs/ntfs/attrib_volume_name.rb
@@ -1,4 +1,4 @@
-require 'util/miq-unicode'
+require 'fs/ntfs/utils'
 
 module NTFS
   #
@@ -15,7 +15,7 @@ module NTFS
 
     def initialize(buf)
       buf   = buf.read(buf.length) if buf.kind_of?(DataRun)
-      @name = buf.UnicodeToUtf8
+      @name = NTFS::Utils.UnicodeToUtf8(buf)
     end
 
     def to_s

--- a/lib/virtfs/ntfs/utils.rb
+++ b/lib/virtfs/ntfs/utils.rb
@@ -39,5 +39,9 @@ module NTFS
         raise "Invalid Signature <#{signature}>"
       end
     end
+
+    def self.UnicodeToUtf8(string)
+      string.dup.force_encoding('UTF-16LE').encode('UTF-8')
+    end
   end
 end


### PR DESCRIPTION
Part of the gems-pending cleanup effort. Since there are only a handful of references, I simply replaced them with the longhand version.

Note that I didn't use `.dup` here since they're already substrings (or in one case, a constant assignment).

Followup to https://github.com/ManageIQ/manageiq-smartstate/pull/149